### PR TITLE
cleanup and refactoring

### DIFF
--- a/service/src/main/java/org/mskcc/cmo/metadb/service/impl/MessageHandlingServiceImpl.java
+++ b/service/src/main/java/org/mskcc/cmo/metadb/service/impl/MessageHandlingServiceImpl.java
@@ -227,7 +227,8 @@ public class MessageHandlingServiceImpl implements MessageHandlingService {
                             LOG.info("Sample metadata does not already exist - persisting to db: "
                                     + sampleMetadata.getPrimaryId());
                             // handle and persist new sample received
-                            MetadbSample sample = SampleDataFactory.buildNewResearchSample(sampleMetadata);
+                            MetadbSample sample = SampleDataFactory
+                                    .buildNewResearchSampleFromMetadata(sampleMetadata);
                             sampleService.saveSampleMetadata(sample);
                             LOG.info("Publishing metadata history for new sample: "
                                     + sampleMetadata.getPrimaryId());
@@ -367,7 +368,7 @@ public class MessageHandlingServiceImpl implements MessageHandlingService {
                     String requestJson = mapper.readValue(
                             new String(msg.getData(), StandardCharsets.UTF_8),
                             String.class);
-                    MetadbRequest request = RequestDataFactory.buildNewLimsRequest(requestJson);
+                    MetadbRequest request = RequestDataFactory.buildNewLimsRequestFromJson(requestJson);
                     LOG.info("Received message on topic: " + IGO_NEW_REQUEST_TOPIC + " and request id: "
                             + request.getRequestId());
                     messageHandlingService.newRequestHandler(request);
@@ -387,7 +388,7 @@ public class MessageHandlingServiceImpl implements MessageHandlingService {
                     String requestMetadataJson = mapper.readValue(
                             new String(msg.getData(), StandardCharsets.UTF_8), String.class);
                     RequestMetadata requestMetadata =
-                            RequestDataFactory.buildNewRequestMetadata(requestMetadataJson);
+                            RequestDataFactory.buildNewRequestMetadataFromMetadata(requestMetadataJson);
                     LOG.info("Received message on topic: "  + IGO_REQUEST_UPDATE_TOPIC + " and request id: "
                             + requestMetadata.getRequestId());
                     messageHandlingService.requestUpdateHandler(requestMetadata);
@@ -409,7 +410,7 @@ public class MessageHandlingServiceImpl implements MessageHandlingService {
                     String sampleMetadataJson = mapper.readValue(
                             new String(msg.getData(), StandardCharsets.UTF_8), String.class);
                     SampleMetadata sampleMetadata =
-                            SampleDataFactory.buildNewSampleMetadata(sampleMetadataJson);
+                            SampleDataFactory.buildNewSampleMetadatafromJson(sampleMetadataJson);
                     messageHandlingService.sampleUpdateHandler(sampleMetadata);
                 } catch (Exception e) {
                     LOG.error("Exception during processing of request update on topic: "

--- a/service/src/main/java/org/mskcc/cmo/metadb/service/impl/SampleServiceImpl.java
+++ b/service/src/main/java/org/mskcc/cmo/metadb/service/impl/SampleServiceImpl.java
@@ -41,7 +41,6 @@ public class SampleServiceImpl implements MetadbSampleService {
     public MetadbSample saveSampleMetadata(MetadbSample
             sample) throws Exception {
         fetchAndLoadSampleDetails(sample);
-        //MetadbSample sample = dataFactory.setMetadbSamplePatientNode(metadbSample);
 
         MetadbSample existingSample =
                 sampleRepository.findSampleByIgoId(sample.getSampleIgoId());
@@ -104,7 +103,6 @@ public class SampleServiceImpl implements MetadbSampleService {
             return null;
         }
         return getAllMetadbSampleFields(sample);
-
     }
 
     @Override
@@ -115,7 +113,6 @@ public class SampleServiceImpl implements MetadbSampleService {
             return null;
         }
         return getAllMetadbSampleFields(sample);
-
     }
 
     @Override

--- a/service/src/main/java/org/mskcc/cmo/metadb/service/util/RequestDataFactory.java
+++ b/service/src/main/java/org/mskcc/cmo/metadb/service/util/RequestDataFactory.java
@@ -27,7 +27,7 @@ public class RequestDataFactory {
      * @return MetadbRequest
      * @throws JsonProcessingException
      */
-    public static MetadbRequest buildNewLimsRequest(String requestJson)
+    public static MetadbRequest buildNewLimsRequestFromJson(String requestJson)
             throws JsonProcessingException {
         MetadbRequest request = mapper.readValue(requestJson,
                 MetadbRequest.class);
@@ -35,7 +35,7 @@ public class RequestDataFactory {
         request.setMetaDbSampleList(extractMetadbSamplesFromIgoResponse(requestJson));
         request.setNamespace("igo");
         // creates and inits request metadata
-        request.addRequestMetadata(extractRequestMetadata(requestJson));
+        request.addRequestMetadata(extractRequestMetadataFromJson(requestJson));
         return request;
     }
 
@@ -60,9 +60,9 @@ public class RequestDataFactory {
      * @return RequestMetadata
      * @throws JsonProcessingException
      */
-    public static RequestMetadata buildNewRequestMetadata(String requestMetadataJson)
+    public static RequestMetadata buildNewRequestMetadataFromMetadata(String requestMetadataJson)
             throws JsonProcessingException {
-        return extractRequestMetadata(requestMetadataJson);
+        return extractRequestMetadataFromJson(requestMetadataJson);
     }
 
     private static List<MetadbSample> extractMetadbSamplesFromIgoResponse(Object message)
@@ -74,13 +74,13 @@ public class RequestDataFactory {
 
         List<MetadbSample> requestSamplesList = new ArrayList<>();
         for (SampleMetadata s: samples) {
-            MetadbSample sample = SampleDataFactory.buildNewResearchSample(requestId, s);
+            MetadbSample sample = SampleDataFactory.buildNewResearchSampleFromMetadata(requestId, s);
             requestSamplesList.add(sample);
         }
         return requestSamplesList;
     }
 
-    private static RequestMetadata extractRequestMetadata(String requestMetadataJson)
+    private static RequestMetadata extractRequestMetadataFromJson(String requestMetadataJson)
             throws JsonMappingException, JsonProcessingException {
         Map<String, Object> requestMetadataMap = mapper.readValue(requestMetadataJson, Map.class);
         // remove samples if present for request metadata

--- a/service/src/main/java/org/mskcc/cmo/metadb/service/util/SampleDataFactory.java
+++ b/service/src/main/java/org/mskcc/cmo/metadb/service/util/SampleDataFactory.java
@@ -19,8 +19,8 @@ public class SampleDataFactory {
      * @param sampleMetadata
      * @return MetadbSample
      */
-    public static MetadbSample buildNewResearchSample(SampleMetadata sampleMetadata) {
-        return buildNewResearchSample(sampleMetadata.getRequestId(), sampleMetadata);
+    public static MetadbSample buildNewResearchSampleFromMetadata(SampleMetadata sampleMetadata) {
+        return buildNewResearchSampleFromMetadata(sampleMetadata.getRequestId(), sampleMetadata);
     }
 
     /**
@@ -29,7 +29,8 @@ public class SampleDataFactory {
      * @param sampleMetadata
      * @return MetadbSample
      */
-    public static MetadbSample buildNewResearchSample(String requestId, SampleMetadata sampleMetadata) {
+    public static MetadbSample buildNewResearchSampleFromMetadata(String requestId,
+            SampleMetadata sampleMetadata) {
         sampleMetadata.setRequestId(requestId);
         sampleMetadata.setImportDate(LocalDateTime.now().format(DateTimeFormatter.ISO_LOCAL_DATE));
 
@@ -53,7 +54,7 @@ public class SampleDataFactory {
      * @param sampleMetadata
      * @return MetadbSample
      */
-    public static MetadbSample buildNewClinicalSample(SampleMetadata sampleMetadata) {
+    public static MetadbSample buildNewClinicalSampleFromMetadata(SampleMetadata sampleMetadata) {
         sampleMetadata.setImportDate(LocalDateTime.now().format(DateTimeFormatter.ISO_LOCAL_DATE));
 
         MetadbSample sample = new MetadbSample();
@@ -77,7 +78,7 @@ public class SampleDataFactory {
      * @return SampleMetadata
      * @throws com.fasterxml.jackson.core.JsonProcessingException
      */
-    public static SampleMetadata buildNewSampleMetadata(String sampleMetadataJson)
+    public static SampleMetadata buildNewSampleMetadatafromJson(String sampleMetadataJson)
             throws JsonProcessingException {
         SampleMetadata sampleMetadata =
                 mapper.readValue(sampleMetadataJson, SampleMetadata.class);

--- a/service/src/test/java/org/mskcc/cmo/metadb/service/PatientServiceTest.java
+++ b/service/src/test/java/org/mskcc/cmo/metadb/service/PatientServiceTest.java
@@ -81,19 +81,19 @@ public class PatientServiceTest {
         // mock request id: MOCKREQUEST1_B
         MockJsonTestData request1Data = mockDataUtils.mockedRequestJsonDataMap
                 .get("mockIncomingRequest1JsonDataWith2T2N");
-        MetadbRequest request1 = RequestDataFactory.buildNewLimsRequest(request1Data.getJsonString());
+        MetadbRequest request1 = RequestDataFactory.buildNewLimsRequestFromJson(request1Data.getJsonString());
         requestService.saveRequest(request1);
 
         // mock request id: 33344_Z
         MockJsonTestData request3Data = mockDataUtils.mockedRequestJsonDataMap
                 .get("mockIncomingRequest3JsonDataPooledNormals");
-        MetadbRequest request3 = RequestDataFactory.buildNewLimsRequest(request3Data.getJsonString());
+        MetadbRequest request3 = RequestDataFactory.buildNewLimsRequestFromJson(request3Data.getJsonString());
         requestService.saveRequest(request3);
 
         // mock request id: 145145_IM
         MockJsonTestData request5Data = mockDataUtils.mockedRequestJsonDataMap
                 .get("mockIncomingRequest5JsonPtMultiSamples");
-        MetadbRequest request5 = RequestDataFactory.buildNewLimsRequest(request5Data.getJsonString());
+        MetadbRequest request5 = RequestDataFactory.buildNewLimsRequestFromJson(request5Data.getJsonString());
         requestService.saveRequest(request5);
     }
 

--- a/service/src/test/java/org/mskcc/cmo/metadb/service/RequestServiceTest.java
+++ b/service/src/test/java/org/mskcc/cmo/metadb/service/RequestServiceTest.java
@@ -82,19 +82,19 @@ public class RequestServiceTest {
         // mock request id: MOCKREQUEST1_B
         MockJsonTestData request1Data = mockDataUtils.mockedRequestJsonDataMap
                 .get("mockIncomingRequest1JsonDataWith2T2N");
-        MetadbRequest request1 = RequestDataFactory.buildNewLimsRequest(request1Data.getJsonString());
+        MetadbRequest request1 = RequestDataFactory.buildNewLimsRequestFromJson(request1Data.getJsonString());
         requestService.saveRequest(request1);
 
         // mock request id: 33344_Z
         MockJsonTestData request3Data = mockDataUtils.mockedRequestJsonDataMap
                 .get("mockIncomingRequest3JsonDataPooledNormals");
-        MetadbRequest request3 = RequestDataFactory.buildNewLimsRequest(request3Data.getJsonString());
+        MetadbRequest request3 = RequestDataFactory.buildNewLimsRequestFromJson(request3Data.getJsonString());
         requestService.saveRequest(request3);
 
         // mock request id: 145145_IM
         MockJsonTestData request5Data = mockDataUtils.mockedRequestJsonDataMap
                 .get("mockIncomingRequest5JsonPtMultiSamples");
-        MetadbRequest request5 = RequestDataFactory.buildNewLimsRequest(request5Data.getJsonString());
+        MetadbRequest request5 = RequestDataFactory.buildNewLimsRequestFromJson(request5Data.getJsonString());
         requestService.saveRequest(request5);
     }
 
@@ -135,7 +135,7 @@ public class RequestServiceTest {
         // get the matching request from the mock data utils
         MockJsonTestData request1Data = mockDataUtils.mockedRequestJsonDataMap
                 .get("mockIncomingRequest1JsonDataWith2T2N");
-        MetadbRequest requestFromMockData = RequestDataFactory.buildNewLimsRequest(
+        MetadbRequest requestFromMockData = RequestDataFactory.buildNewLimsRequestFromJson(
                 request1Data.getJsonString());
         Assertions.assertThat(requestHasExpectedFieldsPopulated(requestFromMockData)).isTrue();
 
@@ -155,7 +155,7 @@ public class RequestServiceTest {
         MetadbRequest origRequest = requestService.getMetadbRequestById(requestId);
         Assertions.assertThat(requestHasExpectedFieldsPopulated(origRequest)).isTrue();
         // this updated request as a different investigator email than its original
-        MetadbRequest updatedRequest = RequestDataFactory.buildNewLimsRequest(
+        MetadbRequest updatedRequest = RequestDataFactory.buildNewLimsRequestFromJson(
                 updatedRequestData.getJsonString());
         Assertions.assertThat(requestHasExpectedFieldsPopulated(updatedRequest)).isTrue();
 
@@ -174,7 +174,7 @@ public class RequestServiceTest {
         // get request from the mock data utils to compare against request in db
         MockJsonTestData request3Data = mockDataUtils.mockedRequestJsonDataMap
                 .get("mockIncomingRequest3JsonDataPooledNormals");
-        MetadbRequest requestFromMockData = RequestDataFactory.buildNewLimsRequest(
+        MetadbRequest requestFromMockData = RequestDataFactory.buildNewLimsRequestFromJson(
                 request3Data.getJsonString());
         Assertions.assertThat(requestHasExpectedFieldsPopulated(requestFromMockData)).isTrue();
 
@@ -191,7 +191,7 @@ public class RequestServiceTest {
     public void testRequestSamplesWithUpdates() throws Exception {
         MockJsonTestData updatedRequestData = mockDataUtils.mockedRequestJsonDataMap
                 .get("mockIncomingRequest1UpdatedJsonDataWith2T2N");
-        MetadbRequest updatedRequest = RequestDataFactory.buildNewLimsRequest(
+        MetadbRequest updatedRequest = RequestDataFactory.buildNewLimsRequestFromJson(
                 updatedRequestData.getJsonString());
         Assertions.assertThat(requestHasExpectedFieldsPopulated(updatedRequest)).isTrue();
 

--- a/service/src/test/java/org/mskcc/cmo/metadb/service/SampleServiceTest.java
+++ b/service/src/test/java/org/mskcc/cmo/metadb/service/SampleServiceTest.java
@@ -85,19 +85,19 @@ public class SampleServiceTest {
         // mock request id: MOCKREQUEST1_B
         MockJsonTestData request1Data = mockDataUtils.mockedRequestJsonDataMap
                 .get("mockIncomingRequest1JsonDataWith2T2N");
-        MetadbRequest request1 = RequestDataFactory.buildNewLimsRequest(request1Data.getJsonString());
+        MetadbRequest request1 = RequestDataFactory.buildNewLimsRequestFromJson(request1Data.getJsonString());
         requestService.saveRequest(request1);
 
         // mock request id: 33344_Z
         MockJsonTestData request3Data = mockDataUtils.mockedRequestJsonDataMap
                 .get("mockIncomingRequest3JsonDataPooledNormals");
-        MetadbRequest request3 = RequestDataFactory.buildNewLimsRequest(request3Data.getJsonString());
+        MetadbRequest request3 = RequestDataFactory.buildNewLimsRequestFromJson(request3Data.getJsonString());
         requestService.saveRequest(request3);
 
         // mock request id: 145145_IM
         MockJsonTestData request5Data = mockDataUtils.mockedRequestJsonDataMap
                 .get("mockIncomingRequest5JsonPtMultiSamples");
-        MetadbRequest request5 = RequestDataFactory.buildNewLimsRequest(request5Data.getJsonString());
+        MetadbRequest request5 = RequestDataFactory.buildNewLimsRequestFromJson(request5Data.getJsonString());
         requestService.saveRequest(request5);
     }
 
@@ -191,7 +191,7 @@ public class SampleServiceTest {
 
         MockJsonTestData updatedRequestData = mockDataUtils.mockedRequestJsonDataMap
                 .get("mockIncomingRequest1UpdatedJsonDataWith2T2N");
-        MetadbRequest updatedRequest = RequestDataFactory.buildNewLimsRequest(
+        MetadbRequest updatedRequest = RequestDataFactory.buildNewLimsRequestFromJson(
                 updatedRequestData.getJsonString());
         MetadbSample updatedSample = updatedRequest.getMetaDbSampleList().get(0);
 
@@ -213,7 +213,7 @@ public class SampleServiceTest {
 
         MockJsonTestData updatedRequestData = mockDataUtils.mockedRequestJsonDataMap
                 .get("mockIncomingRequest1UpdatedJsonDataWith2T2N");
-        MetadbRequest updatedRequest = RequestDataFactory.buildNewLimsRequest(
+        MetadbRequest updatedRequest = RequestDataFactory.buildNewLimsRequestFromJson(
                 updatedRequestData.getJsonString());
         MetadbSample updatedSample = updatedRequest.getMetaDbSampleList().get(1);
         sampleService.saveSampleMetadata(updatedSample);


### PR DESCRIPTION
Signed-off-by: Divya Madala <71040191+divyamadala30@users.noreply.github.com>

# Fix # (see https://help.github.com/en/articles/closing-issues-using-keywords)

Briefly describe changes proposed in this pull request:
- a
- b

--

## Troubleshooting

### Expected behavior

### Actual behavior

### Logs, error output, or stacktrace

### Steps to reproduce the behavior

### Tasks

Include specific tasks in the order they need to be done in. Include links to specific lines of code where the task should happen at.

- [ ] task 1
- [ ] task 2
- [ ] task 3

### Screenshots

--

## Crossing T's and dotting I's

Please follow these checklists to help prevent any unexpected issues from being introduced by the changes in this pull request. If an item does not apply then indicate so by surrounding the line item with `~~` to strikethrough the text. See [basic writing and formatting syntax](https://docs.github.com/en/github/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) for more information.

### Web service and data model checklist

- [ ] Have screenshots been uploaded to demonstrate changes made to the response body JSON schema and/or swagger page?
- [ ] Were updates made to the mocked incoming request data and/or mocked published request data?
  - [ ] [cmo-metadb test data](https://github.com/mskcc/cmo-metadb/tree/master/service/src/test/resources/data)
  - [ ] [cmo-metadb-common test data](https://github.com/mskcc/cmo-metadb-common/tree/master/src/test/resources/data)
- [ ] Have unit tests been updated in relation to updates to the mocked test data?

### Neo4j models and database schema checklist:
- [ ] Were any of the neo4j persistence models changed?
- [ ] Does the graph database produce the expected changes to models, relationships, and/or property names? [provide screenshot of updated elements in graph db]

### Message handlers checklist:
- [ ] Were changes introduced in this PR that may affect the workflow of incoming messages?
- [ ] Are messages following the expected workflow when published to the topic(s) changed in this pull request?
- [ ] Were unit tests added to ensure messages are handled as expected?

If no unit tests were updated or added, then please explain why: [insert details here]

Please describe how the workflow and messaging was tested/simulated:

**Your environment**

- NATS [local, local docker, dev server, production]
- Neo4j [local, local docker, dev server, production]
- MetaDB [local, local docker, dev server, production]
- Message publishing simulation [nats cli, docker nats cli, metadb publisher tool, other (describe below)]

Other: [insert details on how messages were published or simulated for testing]

### Configuration and/or permissions checklist:
- [ ] Were any new topics introduced?
- [ ] Were the topics and appropriate permissions updated in [cmo-metadb-configuration](https://github.mskcc.org/cmo/cmo-metadb-configuration)?
- [ ] If a new account was set up then were the account credentials and keys committed to [cmo-metadb-configuration](https://github.mskcc.org/cmo/cmo-metadb-configuration)?
- [ ] Were the account credentials and keys shared with the appropriate parties?

### General checklist:
- [ ] Have tests or has a separate issue that describes the types of tests that should be created been linked or created? If no test is included it should explicitly be mentioned in the PR why there is no test.
- [ ] The commit log is comprehensible. It follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
